### PR TITLE
Updates api route for service types

### DIFF
--- a/src/state/actions/ServiceTypeActions.js
+++ b/src/state/actions/ServiceTypeActions.js
@@ -61,7 +61,7 @@ export const editServiceTypeAction = (typeId, typeObj) => dispatch => {
   dispatch({ type: EDIT_SERVICE_TYPE_START });
 
   axiosWithAuth()
-    .put(`/api/service/${typeId}`, typeObj)
+    .put(`/api/service_type/${typeId}`, typeObj)
     .then(res => {
       dispatch({ type: EDIT_SERVICE_TYPE_SUCCESS, payload: res.data });
     })
@@ -77,7 +77,7 @@ export const deleteServiceTypeAction = typeId => dispatch => {
   dispatch({ type: DELETE_SERVICE_TYPE_START });
 
   axiosWithAuth()
-    .delete(`/api/service/${typeId}`)
+    .delete(`/api/service_type/${typeId}`)
     .then(res => {
       dispatch({ type: DELETE_SERVICE_TYPE_SUCCESS, payload: res.data });
     })


### PR DESCRIPTION
This PR fixes the API calls to use correct routes for service types. At the time this file was initially committed, there was a typo in the API readme that had some service types routes as 'api/service_type' and some as 'api/service'.

### Description

**What work was done?**
Fixes bug that was requesting an invalid endpoint for service_types from the API

**What feature / user story is it for?**
https://trello.com/c/qB7xchqU


### Type of change
[x] Bug fix

Change Status
[x] Completed, ready to review and merge
Has This Been Tested
[x] Yes

### Checklist
[] My code follows the style guidelines of this project
[] I have performed a self-review of my own code
[] My code has been reviewed by at least one peer
[] I have commented my code, particularly in hard-to-understand areas
[] I have made corresponding changes to the documentation
[] My changes generate no new warnings
[] There are no merge conflicts
