### PR TITLE
Role properly being removed from LS on logout

### DIFF
--- a/src/components/common/Navbar/HamburgerMenu.js
+++ b/src/components/common/Navbar/HamburgerMenu.js
@@ -32,6 +32,7 @@ const HamburgerMenu = () => {
     localStorage.removeItem('okta-token-storage');
     localStorage.removeItem('okta-cache-storage');
     localStorage.removeItem('username');
+    localStorage.removeItem('role');
     history.push('/login');
     window.location.reload(); // quick fix need to change later
   };


### PR DESCRIPTION
### Description
- Added 
``` localStorage.removeItem('role')```
to handleLockout function in HamburgerMenu.js 

- This properly removes role and it's value from local storage on logout event.

### Type of change
- Bug fix

- Tested Locally

Change Status
- Completed, ready to review and merge
- This fix eliminates this issue, but reveals another. It appears the components is rendering before it receives the "role" data which is necessary to render the proper navigation. In this case it does NOT render a navigation bar after logging in the first time (in my local testing). There was a "quick fix" from the previous team holding this together, but we'll have to find another solution to wait until the proper data is received to render the navigation [Quick Fix](https://drive.google.com/file/d/1U-dNqcztIWiCSbVBOPHD4VWrO8gQqmuX/view?usp=sharing)

- Added Jacob and Ashish as reviewers
