### PR TITLE
Fixed quantity bug to not go negative. added max

### DIFF
--- a/src/components/forms/AddServiceForm.js
+++ b/src/components/forms/AddServiceForm.js
@@ -113,7 +113,7 @@ function AddServiceForm({
           </Form.Item>
 
           <Form.Item label="Quantity" name="quantity">
-            <InputNumber size="large" />
+            <InputNumber min={0} max={100} />
           </Form.Item>
           <Form.Item
             label="Status"


### PR DESCRIPTION
### Description

**Invited Collaborator(s) to Review
- Added person to review relating to feature/bug
- If not available, ask another reviewer on team

**What work was done?**
- Describe in detail what's been modified/created
- Changed quantity min and max in the add service form so it can only go down to 0 and max is 100 (will change if need be)
- It cannot go negative.

**Why was this work done?**
- What is the purpose of the feature?
- Realistically, if someone were to log a service, you cannot have a negative number inputted and there is a limit as well.

**What feature / user story is it for?**
(Link if possible) 
**Any relevant links or images / screenshots**
- Log a Service: As a user, I should not be able to input a negative Quantity

### Type of change
Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

Testing
- Has this feature been tested before conflict?
- Has this feature been tested after conflict?

Change Status
- Completed, ready to review and merge

### Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- My code has been reviewed by at least one peer
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- There are no merge conflicts
