### PR TITLE
Fixed TypeError when users login with no programs assigned thus crashing the site.

### DIFF
--- a/src/components/pages/MyProfile/RenderMyProfile.js
+++ b/src/components/pages/MyProfile/RenderMyProfile.js
@@ -89,7 +89,9 @@ function RenderMyProfile({
           <div>
             {curUser.programs.map(program => (
               <>
-                <h4>{program.name}</h4>
+                <h4>
+                  {program ? program.name : 'No Programs Currently Assigned'}
+                </h4>
               </>
             ))}
           </div>
@@ -117,7 +119,7 @@ function RenderMyProfile({
               onClick={handleEdit}
               className="profile-btn"
             >
-              Edit Name
+              Edit Profile
             </Button>
           )}
           {isInEditMode && (
@@ -127,7 +129,7 @@ function RenderMyProfile({
               onClick={onSubmit}
               className="profile-btn"
             >
-              Save Name
+              Save Profile
             </Button>
           )}
         </div>


### PR DESCRIPTION
### Description

**Invited Collaborator(s) to Review
- Ashish Goomar

**What work was done?**
RenderMyProfile.js File:
- Fixed error "Cannot read property 'name' of null" when certain users with no programs assigned log into the application. A turnery operator was implemented in case a user has no programs assigned to them, thus returning "No Programs Currently Assigned". See screen capture below of resolved error specifically for user "Sally Service". Line 92 -> Line 92 - 94.
- Revised "Edit Name" -> "Edit Profile" for purpose clarity. Line 120 -> Line 122
- Revised "Save Name" -> "Save Profile" for purpose clarity. Line 130 - > Line 132

**Why was this work done?**
- This was done so the users can login properly and not see an error, if they have no programs assigned to them.
- "Edit Name" and "Save Name" buttons were changed for naming clarity of the button's purpose. The buttons alone do not only change the name but change the avatar profile photo as well, thus "Edit Profile" and "Save Profile" make more sense.

**What feature / user story is it for?**
- This is a general error fix so the user can properly login.
- Proper naming for profile editing buttons so users know they can edit their profile, not just their name.

Testing
- Has this feature been tested before conflict?
- Yes, by all provided user logins.
- Has this feature been tested after conflict?
- Yes, by all provided user logins.

Change Status
- Completed, ready to review and merge

### Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- My code has been reviewed by at least one peer
- My changes generate no new warnings
- There are no merge conflicts

Photo of resolved problem:
![bugfix-programs-null](https://user-images.githubusercontent.com/70069996/118707702-d6dc7580-b7e8-11eb-981f-26d4cb73fd35.JPG)