### PR TITLE
Feature/media query orientation

### DIFF
--- a/src/styles/Layout.scss
+++ b/src/styles/Layout.scss
@@ -21,6 +21,12 @@
   font-size: 11px;
   border:.5px solid gray;
 
+  @media(orientation:portrait){ 
+    font-size:9px;
+  }
+  @media(orientation:landscape){ 
+    font-size:11px;
+  }
   @media (min-width: 1200px) {
     font-size:15px;
   }


### PR DESCRIPTION
Added media query for device orientation so the text fits better in the tables, portrait mode text is 9px and landscape is 11px. 
https://user-images.githubusercontent.com/64627086/119193236-324f7300-ba36-11eb-95e9-8b6fcc4d3ac2.mp4

