### PR TITLE
fixes axiosWithAuth to use env instead of hard coded

### DIFF
--- a/src/utils/axiosWithAuth.js
+++ b/src/utils/axiosWithAuth.js
@@ -7,6 +7,6 @@ export const axiosWithAuth = () => {
     headers: {
       Authorization: `Bearer ${token}`,
     },
-    baseURL: 'https://fp-service-tracker.herokuapp.com',
+    baseURL: process.env.REACT_APP_API_URI,
   });
 };


### PR DESCRIPTION
### Description

**What work was done?**
Updates axiosWithAuth helper to use ENV instead of hard coded domain

**Why was this work done?**
To follow proper engineering standards and allow local devs to use local backend

