### PR TITLE
Bug/service type redux errors

### DIFF
--- a/src/components/common/ServicesTable/ServiceTable.js
+++ b/src/components/common/ServicesTable/ServiceTable.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { STATUSES } from '../../../const';
 import {
@@ -19,9 +19,6 @@ import {
 
 // Action Imports
 import {
-  getAllServicesAction,
-  getAllRecipientAction,
-  getAllServiceTypesAction,
   deleteServiceAction,
   editServiceAction,
   getServiceByIdAction,
@@ -31,11 +28,8 @@ import {
 } from '../../../state/actions';
 
 const ServicesTable = ({
-  getAllServicesAction,
   deleteServiceAction,
   editServiceAction,
-  getAllRecipientAction,
-  getAllServiceTypesAction,
   services,
   change,
 }) => {
@@ -43,17 +37,6 @@ const ServicesTable = ({
   const [editingKey, setEditingKey] = useState('');
   const [sortedInfo, setSortedInfo] = useState('');
   const [filteredInfo, setFilteredInfo] = useState('');
-
-  useEffect(() => {
-    getAllRecipientAction();
-    getAllServicesAction();
-    getAllServiceTypesAction();
-  }, [
-    change,
-    getAllRecipientAction,
-    getAllServiceTypesAction,
-    getAllServicesAction,
-  ]);
 
   const handleChange = (filters, sorter) => {
     setSortedInfo(sorter);
@@ -586,18 +569,14 @@ const mapStateToProps = state => {
   return {
     recipient: state.recipient.recipients,
     services: state.service.services,
-    serviceTypes: state.service.serviceTypes,
-    change: state.recipient.change,
+    serviceTypes: state.serviceType.serviceTypes,
   };
 };
 
 export default connect(mapStateToProps, {
-  getAllServicesAction,
   deleteServiceAction,
   editServiceAction,
   getServiceByIdAction,
-  getAllRecipientAction,
-  getAllServiceTypesAction,
   addRecipientAction,
   editRecipientAction,
   deleteRecipientAction,

--- a/src/components/forms/AddServiceForm.js
+++ b/src/components/forms/AddServiceForm.js
@@ -5,7 +5,6 @@ import { STATUSES } from '../../const';
 import {
   getServiceProviders,
   addServiceAction,
-  getServiceTypes,
 } from '../../state/actions/serviceActions';
 
 const { TextArea } = Input;
@@ -218,11 +217,10 @@ const mapStateToProps = state => {
   return {
     serviceProviders: state.service.serviceProviders,
     recipients: state.recipient.recipients,
-    serviceTypes: state.service.serviceTypes,
+    serviceTypes: state.serviceType.serviceTypes,
   };
 };
 export default connect(mapStateToProps, {
   addServiceAction,
   getServiceProviders,
-  getServiceTypes,
 })(AddServiceForm);

--- a/src/components/forms/AddServiceTypeForm.js
+++ b/src/components/forms/AddServiceTypeForm.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-
 import { Form, Input, Select, Modal } from 'antd';
-import { getAllProgramsAction } from '../../state/actions/programActions';
 
 function AddServiceTypeForm({ onCreate, onCancel, visible, programs }) {
   const [form] = Form.useForm();
@@ -80,6 +78,4 @@ const mapStateToProps = state => {
     programs: state.program.programs,
   };
 };
-export default connect(mapStateToProps, {
-  getAllProgramsAction,
-})(AddServiceTypeForm);
+export default connect(mapStateToProps, null)(AddServiceTypeForm);

--- a/src/components/pages/Services/RenderServicesPage.js
+++ b/src/components/pages/Services/RenderServicesPage.js
@@ -6,10 +6,11 @@ import { connect } from 'react-redux';
 import {
   addServiceAction,
   getServiceProviders,
-  getServiceTypes,
+  getAllServiceTypesAction,
   getAllProgramsAction,
   getAllRecipientAction,
   addServiceTypeAction,
+  getAllServicesAction,
 } from '../../../state/actions/index';
 
 //component import
@@ -19,8 +20,9 @@ import AddServiceTypeForm from '../../forms/AddServiceTypeForm';
 function RenderServicesPage({
   addServiceAction,
   getServiceProviders,
+  getAllServicesAction,
   getAllRecipientAction,
-  getServiceTypes,
+  getAllServiceTypesAction,
   getAllProgramsAction,
   addServiceTypeAction,
 }) {
@@ -28,14 +30,16 @@ function RenderServicesPage({
   const [typeVisible, setTypeVisible] = useState(false);
 
   useEffect(() => {
+    getAllServicesAction();
     getServiceProviders();
     getAllRecipientAction();
-    getServiceTypes();
+    getAllServiceTypesAction();
     getAllProgramsAction();
   }, [
+    getAllServicesAction,
     getServiceProviders,
     getAllRecipientAction,
-    getServiceTypes,
+    getAllServiceTypesAction,
     getAllProgramsAction,
   ]);
 
@@ -93,7 +97,7 @@ function RenderServicesPage({
 const mapStateToProps = state => {
   return {
     serviceProviders: state.service.serviceProviders,
-    serviceTypes: state.service.serviceTypes,
+    serviceTypes: state.serviceType.serviceTypes,
     recipients: state.recipient.recipients,
     programs: state.program.programs,
   };
@@ -102,8 +106,9 @@ const mapStateToProps = state => {
 export default connect(mapStateToProps, {
   addServiceAction,
   addServiceTypeAction,
+  getAllServicesAction,
   getServiceProviders,
   getAllRecipientAction,
-  getServiceTypes,
+  getAllServiceTypesAction,
   getAllProgramsAction,
 })(RenderServicesPage);

--- a/src/state/actions/ServiceTypeActions.js
+++ b/src/state/actions/ServiceTypeActions.js
@@ -1,14 +1,9 @@
 import { axiosWithAuth } from '../../utils/axiosWithAuth';
 
-export const GET_ALL_SERVICE_TYPE_START = 'GET_ALL_SERVICE_TYPE_START';
-export const GET_ALL_SERVICE_TYPE_SUCCESS = 'GET_ALL_SERVICE_TYPE_SUCCESS';
-export const GET_ALL_SERVICE_TYPE_FAIL = 'GET_ALL_SERVICE_TYPE_FAIL';
-export const GET_ALL_SERVICE_TYPE_RESOLVE = 'GET_ALL_SERVICE_TYPE_RESOLVE';
-
-// export const ADD_SERVICE_TYPE_START = 'ADD_SERVICE_TYPE_START'
-// export const ADD_SERVICE_TYPE_SUCCESS = 'ADD_SERVICE_TYPE_SUCCESS'
-// export const ADD_SERVICE_TYPE_FAIL= 'ADD_SERVICE_TYPE_FAIL'
-// export const ADD_SERVICE_TYPE_RESOLVE= 'ADD_SERVICE_TYPE_RESOLVE'
+export const GET_ALL_SERVICE_TYPES_START = 'GET_ALL_SERVICE_TYPES_START';
+export const GET_ALL_SERVICE_TYPES_SUCCESS = 'GET_ALL_SERVICE_TYPES_SUCCESS';
+export const GET_ALL_SERVICE_TYPES_FAIL = 'GET_ALL_SERVICE_TYPES_FAIL';
+export const GET_ALL_SERVICE_TYPES_RESOLVE = 'GET_ALL_SERVICE_TYPES_RESOLVE';
 
 export const GET_SERVICE_TYPE_START = 'GET_SERVICE_TYPE_START';
 export const GET_SERVICE_TYPE_SUCCESS = 'GET_SERVICE_TYPE_SUCCESS';
@@ -31,18 +26,18 @@ export const DELETE_SERVICE_TYPE_FAIL = 'DELETE_SERVICE_TYPE_FAIL';
 export const DELETE_SERVICE_TYPE_RESOLVE = 'DELETE_SERVICE_TYPE_RESOLVE';
 
 export const getAllServiceTypesAction = () => dispatch => {
-  dispatch({ type: GET_ALL_SERVICE_TYPE_START });
+  dispatch({ type: GET_ALL_SERVICE_TYPES_START });
 
   axiosWithAuth()
     .get('/api/service_types')
     .then(res => {
-      dispatch({ type: GET_ALL_SERVICE_TYPE_SUCCESS, payload: res.data });
+      dispatch({ type: GET_ALL_SERVICE_TYPES_SUCCESS, payload: res.data });
     })
     .catch(err => {
-      dispatch({ type: GET_ALL_SERVICE_TYPE_FAIL, payload: err.message });
+      dispatch({ type: GET_ALL_SERVICE_TYPES_FAIL, payload: err.message });
     })
     .finally(() => {
-      dispatch({ type: GET_ALL_SERVICE_TYPE_RESOLVE });
+      dispatch({ type: GET_ALL_SERVICE_TYPES_RESOLVE });
     });
 };
 
@@ -83,7 +78,10 @@ export const addServiceTypeAction = typeObj => dispatch => {
   axiosWithAuth()
     .post(`/api/service_types/`, typeObj)
     .then(res => {
-      dispatch({ type: ADD_SERVICE_TYPE_SUCCESS, payload: res.data });
+      dispatch({
+        type: ADD_SERVICE_TYPE_SUCCESS,
+        payload: res.data.service_type,
+      });
     })
     .catch(err => {
       dispatch({ type: ADD_SERVICE_TYPE_FAIL, payload: err.message });

--- a/src/state/actions/ServiceTypeActions.js
+++ b/src/state/actions/ServiceTypeActions.js
@@ -63,7 +63,10 @@ export const editServiceTypeAction = (typeId, typeObj) => dispatch => {
   axiosWithAuth()
     .put(`/api/service_type/${typeId}`, typeObj)
     .then(res => {
-      dispatch({ type: EDIT_SERVICE_TYPE_SUCCESS, payload: res.data });
+      dispatch({
+        type: EDIT_SERVICE_TYPE_SUCCESS,
+        payload: res.data.service_type,
+      });
     })
     .catch(err => {
       dispatch({ type: EDIT_SERVICE_TYPE_FAIL, payload: err.message });
@@ -97,7 +100,10 @@ export const deleteServiceTypeAction = typeId => dispatch => {
   axiosWithAuth()
     .delete(`/api/service_type/${typeId}`)
     .then(res => {
-      dispatch({ type: DELETE_SERVICE_TYPE_SUCCESS, payload: res.data });
+      // backend is returning id of deleted object in a message string - this is a
+      // brittle method to get that id but will work without making backend changes
+      const id = res.data.message.match(/\d+/)[0];
+      dispatch({ type: DELETE_SERVICE_TYPE_SUCCESS, payload: id });
     })
     .catch(err => {
       dispatch({ type: DELETE_SERVICE_TYPE_FAIL, payload: err.message });

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -13,7 +13,6 @@ export {
   editServiceAction,
   deleteServiceAction,
   getServiceProviders,
-  getServiceTypes,
 } from './serviceActions';
 
 export {

--- a/src/state/actions/serviceActions.js
+++ b/src/state/actions/serviceActions.js
@@ -35,11 +35,6 @@ export const GET_ALL_SERVICE_PROVIDERS_FAIL = 'GET_ALL_SERVICE_PROVIDERS_FAIL';
 export const GET_ALL_SERVICE_PROVIDERS_RESOLVE =
   'GET_ALL_SERVICE_PROVIDERS_RESOLVE';
 
-export const GET_ALL_SERVICE_TYPES_START = 'GET_ALL_SERVICE_TYPES_START';
-export const GET_ALL_SERVICE_TYPES_SUCCESS = 'GET_ALL_SERVICE_TYPES_SUCCESS';
-export const GET_ALL_SERVICE_TYPES_FAIL = 'GET_ALL_SERVICE_TYPES_FAIL';
-export const GET_ALL_SERVICE_TYPES_RESOLVE = 'GET_ALL_SERVICE_TYPES_RESOLVE';
-
 // SERVICES ACTIONS
 
 export const getAllServicesAction = () => dispatch => {
@@ -133,21 +128,5 @@ export const getServiceProviders = () => dispatch => {
     })
     .finally(() => {
       dispatch({ type: GET_ALL_SERVICE_PROVIDERS_RESOLVE });
-    });
-};
-
-export const getServiceTypes = () => dispatch => {
-  dispatch({ type: GET_ALL_SERVICE_TYPES_START });
-
-  axiosWithAuth()
-    .get(`api/service_types`)
-    .then(res => {
-      dispatch({ type: GET_ALL_SERVICE_TYPES_SUCCESS, payload: res.data });
-    })
-    .catch(err => {
-      dispatch({ type: GET_ALL_SERVICE_TYPES_FAIL, payload: err.message });
-    })
-    .finally(() => {
-      dispatch({ type: GET_ALL_SERVICE_TYPES_RESOLVE });
     });
 };

--- a/src/state/reducers/serviceReducer.js
+++ b/src/state/reducers/serviceReducer.js
@@ -23,10 +23,6 @@ import {
   GET_ALL_SERVICE_PROVIDERS_SUCCESS,
   GET_ALL_SERVICE_PROVIDERS_FAIL,
   GET_ALL_SERVICE_PROVIDERS_RESOLVE,
-  GET_ALL_SERVICE_TYPES_START,
-  GET_ALL_SERVICE_TYPES_SUCCESS,
-  GET_ALL_SERVICE_TYPES_FAIL,
-  GET_ALL_SERVICE_TYPES_RESOLVE,
 } from '../actions/serviceActions';
 
 // Initial Service State
@@ -34,7 +30,6 @@ import {
 export const initialServiceState = {
   services: [],
   serviceProviders: [],
-  serviceTypes: [],
   status: 'Resolved',
   change: '',
   error: '',
@@ -180,29 +175,6 @@ export const serviceReducer = (state = initialServiceState, action) => {
         error: action.payload,
       };
     case GET_ALL_SERVICE_PROVIDERS_RESOLVE:
-      return {
-        ...state,
-        status: 'Resolved',
-      };
-    // Get all service types
-    case GET_ALL_SERVICE_TYPES_START:
-      return {
-        ...state,
-        status: 'Pending...',
-      };
-    case GET_ALL_SERVICE_TYPES_SUCCESS:
-      return {
-        ...state,
-        serviceTypes: action.payload,
-        status: 'Success',
-      };
-    case GET_ALL_SERVICE_TYPES_FAIL:
-      return {
-        ...state,
-        status: 'Failed',
-        error: action.payload,
-      };
-    case GET_ALL_SERVICE_TYPES_RESOLVE:
       return {
         ...state,
         status: 'Resolved',

--- a/src/state/reducers/serviceTypeReducer.js
+++ b/src/state/reducers/serviceTypeReducer.js
@@ -1,8 +1,8 @@
 import {
-  GET_ALL_SERVICE_TYPE_START,
-  GET_ALL_SERVICE_TYPE_SUCCESS,
-  GET_ALL_SERVICE_TYPE_FAIL,
-  GET_ALL_SERVICE_TYPE_RESOLVE,
+  GET_ALL_SERVICE_TYPES_START,
+  GET_ALL_SERVICE_TYPES_SUCCESS,
+  GET_ALL_SERVICE_TYPES_FAIL,
+  GET_ALL_SERVICE_TYPES_RESOLVE,
   GET_SERVICE_TYPE_START,
   GET_SERVICE_TYPE_SUCCESS,
   GET_SERVICE_TYPE_FAIL,
@@ -32,24 +32,24 @@ export const initialServiceTypeState = {
 export const serviceTypeReducer = (state = initialServiceTypeState, action) => {
   switch (action.type) {
     //get all service types
-    case GET_ALL_SERVICE_TYPE_START:
+    case GET_ALL_SERVICE_TYPES_START:
       return {
         ...state,
         status: 'Pending...',
       };
-    case GET_ALL_SERVICE_TYPE_SUCCESS:
+    case GET_ALL_SERVICE_TYPES_SUCCESS:
       return {
         ...state,
-        types: action.payload,
+        serviceTypes: action.payload,
         status: 'Success',
       };
-    case GET_ALL_SERVICE_TYPE_FAIL:
+    case GET_ALL_SERVICE_TYPES_FAIL:
       return {
         ...state,
         status: 'Failed',
         error: action.payload,
       };
-    case GET_ALL_SERVICE_TYPE_RESOLVE:
+    case GET_ALL_SERVICE_TYPES_RESOLVE:
       return {
         ...state,
         status: 'Resolved',
@@ -63,7 +63,7 @@ export const serviceTypeReducer = (state = initialServiceTypeState, action) => {
     case GET_SERVICE_TYPE_SUCCESS:
       return {
         ...state,
-        type: action.payload,
+        serviceType: action.payload,
         status: 'Success',
       };
     case GET_SERVICE_TYPE_FAIL:
@@ -87,6 +87,7 @@ export const serviceTypeReducer = (state = initialServiceTypeState, action) => {
       return {
         ...state,
         status: 'Success',
+        serviceTypes: [...state.serviceTypes, action.payload],
         change: 'added',
       };
     case ADD_SERVICE_TYPE_FAIL:

--- a/src/state/reducers/serviceTypeReducer.js
+++ b/src/state/reducers/serviceTypeReducer.js
@@ -112,6 +112,9 @@ export const serviceTypeReducer = (state = initialServiceTypeState, action) => {
       return {
         ...state,
         status: 'Success',
+        serviceTypes: state.serviceTypes.map(serviceType =>
+          serviceType.id === action.payload.id ? action.payload : serviceType
+        ),
         change: 'edited',
       };
     case EDIT_SERVICE_TYPE_FAIL:
@@ -137,6 +140,9 @@ export const serviceTypeReducer = (state = initialServiceTypeState, action) => {
       return {
         ...state,
         status: 'Success',
+        serviceTypes: state.serviceTypes.filter(
+          serviceType => serviceType.id !== action.payload
+        ),
         change: 'deleted',
       };
     case DELETE_SERVICE_TYPE_FAIL:


### PR DESCRIPTION
### Description

**What work was done?**
This fixes the various problems with the redux setup for service types:
- when creating new service type it's added to state
- when editing service type the updates are stored into state
- when deleting service type the deleted object is removed from state
- removes the redundant getServiceTypes actions from the service reducer
- removes redundant requests to backend and consolidates fetch actions to container file rather than spread amongst various components

**Why was this work done?**
There was a bug where you could add a new service type but then not use that service type when logging a service until you refreshed the page. When debugging this issue I realized that there were a lot of things broken with this code so made  a lot of updates to fix them all. 