### PR TITLE
fixed the protected routes

### DIFF
--- a/src/components/pages/Employees/RenderEmployeesPage.js
+++ b/src/components/pages/Employees/RenderEmployeesPage.js
@@ -3,8 +3,15 @@ import { addEmployeeAction } from '../../../state/actions';
 import { connect } from 'react-redux';
 import { Button } from 'antd';
 import AddEmployeeForm from '../../forms/AddEmployeeForm';
+import { useHistory } from 'react-router-dom';
 
-function RenderEmployeePage({ addEmployeeAction }) {
+function RenderEmployeePage({ addEmployeeAction, user }) {
+  // instead of using Okta Groups, simple react-router-dom is used for convenience
+  // permission clauses based on "src/common/Navbar/HamburgerMenu.js"
+  const history = useHistory();
+  if (user.role !== "administrator")
+    history.push("/");
+
   const [visible, setVisible] = useState(false);
 
   const onCreate = employeeObj => {
@@ -35,4 +42,10 @@ function RenderEmployeePage({ addEmployeeAction }) {
   );
 }
 
-export default connect(null, { addEmployeeAction })(RenderEmployeePage);
+const mapStateToProps = state => {
+  return {
+    user: state.user.user
+  };
+};
+
+export default connect(mapStateToProps, { addEmployeeAction })(RenderEmployeePage);

--- a/src/components/pages/Programs/RenderProgramsPage.js
+++ b/src/components/pages/Programs/RenderProgramsPage.js
@@ -6,8 +6,15 @@ import {
 } from '../../../state/actions/index.js';
 import { connect } from 'react-redux';
 import { Button } from 'antd';
+import { useHistory } from 'react-router-dom';
 
-function RenderProgramsPage({ addProgramAction, getAllProgramsAction }) {
+function RenderProgramsPage({ addProgramAction, getAllProgramsAction, user }) {
+  // instead of using Okta Groups, simple react-router-dom is used for convenience
+  // permission clauses based on "src/common/Navbar/HamburgerMenu.js"
+  const history = useHistory();
+  if (user.role !== "administrator" || user.role !== "program_manager")
+    history.push("/");
+
   const [visible, setVisible] = useState(false);
 
   const onCreate = programObj => {
@@ -38,6 +45,7 @@ function RenderProgramsPage({ addProgramAction, getAllProgramsAction }) {
 
 const mapStateToProps = state => {
   return {
+    user: state.user.user,
     programs: state.program.programs,
   };
 };


### PR DESCRIPTION
**Bug**
- routes weren't properly protected
- any user could access (and modify) any page's data

**Fix**
- Okta's <SecureRoute> only seems to have the ability to check if the user is authenticated, so anybody signed in returns true
- Instead of using Okta's Groups feature to specify users & permissions, I used the existing *react-router-dom* package to send the user to home by default
- It's a hacky fix, but it's reasonable to assume there won't be more user types added in the future, and if there is, devs would have to add an additional Okta user group anyway, so this is probably the best solution