### PR TITLE
Got Service Providers Rendering In Log A Service Form

### DIFF
--- a/src/components/common/ServicesTable/ServiceTable.js
+++ b/src/components/common/ServicesTable/ServiceTable.js
@@ -37,6 +37,7 @@ const ServicesTable = ({
   services,
   serviceTypes,
   recipients,
+  serviceProviders,
 }) => {
   const [form] = Form.useForm();
   const [editingKey, setEditingKey] = useState('');
@@ -66,6 +67,44 @@ const ServicesTable = ({
   };
 
   const columns = [
+    {
+      title: 'Date Provided',
+      dataIndex: 'date',
+      key: 'date',
+      width: 100,
+      editable: true,
+      sorter: (a, b) => moment(a.provided_at) - moment(b.provided_at),
+      sortOrder: sortedInfo.columnKey === 'date' && sortedInfo.order,
+      defaultSortOrder: 'descend',
+      render: (_, record) => {
+        const editable = isEditing(record);
+        return editable ? (
+          <Form.Item
+            name="service_date"
+            initialValue={moment(record.service_date)}
+            rules={[
+              {
+                required: true,
+                message: 'Enter Date',
+              },
+            ]}
+          >
+            <DatePicker
+              showTime
+              use12Hours
+              format="MMMM Do YYYY, h:mm a"
+              size="medium"
+            />
+          </Form.Item>
+        ) : (
+          <>
+            {moment(record.service_date).format('MMM Do YYYY')}
+            <br />
+            {moment(record.service_date).format('h:mm a')}
+          </>
+        );
+      },
+    },
     {
       title: 'Service Type',
       dataIndex: 'service_type',
@@ -385,43 +424,7 @@ const ServicesTable = ({
         );
       },
     },
-    {
-      title: 'Date Provided',
-      dataIndex: 'date',
-      key: 'date',
-      editable: true,
-      sorter: (a, b) => moment(a.provided_at) - moment(b.provided_at),
-      sortOrder: sortedInfo.columnKey === 'date' && sortedInfo.order,
-      defaultSortOrder: 'descend',
-      render: (_, record) => {
-        const editable = isEditing(record);
-        return editable ? (
-          <Form.Item
-            name="service_date"
-            initialValue={moment(record.service_date)}
-            rules={[
-              {
-                required: true,
-                message: 'Enter Date',
-              },
-            ]}
-          >
-            <DatePicker
-              showTime
-              use12Hours
-              format="MMMM Do YYYY, h:mm a"
-              size="medium"
-            />
-          </Form.Item>
-        ) : (
-          <>
-            {moment(record.service_date).format('MMM Do YYYY')}
-            <br />
-            {moment(record.service_date).format('h:mm a')}
-          </>
-        );
-      },
-    },
+
     {
       title: 'Actions',
       dataIndex: 'actions',
@@ -467,6 +470,8 @@ const ServicesTable = ({
 
   return (
     <div className="servicesTable">
+      {console.log('LOOK HERE', services)}
+      {console.log('LOOK HERE ALSO', serviceProviders)}
       {services.length < 1 && <LoadingOutlined className="loader" />},
       {services.length >= 1 && (
         <Form form={form}>
@@ -500,6 +505,7 @@ const mapStateToProps = state => {
     recipients: state.recipient.recipients,
     services: state.service.services,
     serviceTypes: state.serviceType.serviceTypes,
+    serviceProviders: state.serviceProviders,
   };
 };
 

--- a/src/components/forms/AddServiceForm.js
+++ b/src/components/forms/AddServiceForm.js
@@ -116,8 +116,13 @@ function AddServiceForm({
           >
             <Select placeholder="Select Provider" size="large">
               {serviceProviders.map(provider => (
-                <Select.Option key={provider.id} value={provider.id}>
-                  {provider.firstName + ' ' + provider.lastName}
+                <Select.Option
+                  key={provider.provider_id}
+                  value={provider.provider_id}
+                >
+                  {provider.provider_first_name +
+                    ' ' +
+                    provider.provider_last_name}
                 </Select.Option>
               ))}
             </Select>

--- a/src/state/actions/serviceActions.js
+++ b/src/state/actions/serviceActions.js
@@ -122,8 +122,9 @@ export const getServiceProviders = () => dispatch => {
   dispatch({ type: GET_ALL_SERVICE_PROVIDERS_START });
 
   axiosWithAuth()
-    .get(`api/providers/getserviceproviders`)
+    .get(`api/providers`)
     .then(res => {
+      console.log('PROVIDERS', res.data);
       dispatch({ type: GET_ALL_SERVICE_PROVIDERS_SUCCESS, payload: res.data });
     })
     .catch(err => {


### PR DESCRIPTION
### Description



**What work was done?**
-Fixed get service providers action in serviceActions as well as property names in addAServiceForm component that mapped through service providers, so now data is being properly pulled into log a service form 
-fixed width of date column in services table and moved to front of table for better UX / organization 

**Why was this work done?**

We fixed service providers because that data is necessary to properly filling out the log a service form, as well as to ensure our backends/frontends are communicating properly.

We made changes to the services table to improve the user experience of our users when analyzing services, they would want to be able to know what date they're looking at right away. 


- What is the purpose of the feature?

To seamlessly fill out the log a service form when on-site assisting someone in need as well as to be able to easily understand what services have been rendered over a specific time period.

**What feature / user story is it for?**

https://trello.com/c/CE8PYkjA


**Any relevant links or images / screenshots**

https://lambda-students.slack.com/archives/C02AFKQBD2L/p1628624807174800

### Type of change
- Fixing existing feature (non-breaking change which adds functionality)

Change Status
- Completed, ready to review and merge

### Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- My code has been reviewed by at least one peer
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- There are no merge conflicts
