### PR TITLE
Renamed Log-A-Service Location Fields

### DIFF
--- a/src/components/forms/AddServiceForm.js
+++ b/src/components/forms/AddServiceForm.js
@@ -178,7 +178,7 @@ function AddServiceForm({
             </Select>
           </Form.Item>
           <Form.Item
-            label="Recipient Address"
+            label="Address Where Service Received"
             name="address"
             rules={[
               {
@@ -190,7 +190,7 @@ function AddServiceForm({
             <Input placeholder="Enter Street Address" size="large" />
           </Form.Item>
           <Form.Item
-            label="Recipient City"
+            label="City Where Service Received"
             name="city"
             rules={[
               {
@@ -202,7 +202,7 @@ function AddServiceForm({
             <Input placeholder="Enter City" size="large" />
           </Form.Item>
           <Form.Item
-            label="Recipient State"
+            label="State Where Service Received"
             name="state"
             rules={[
               {
@@ -214,7 +214,7 @@ function AddServiceForm({
             <Input placeholder="Enter State" size="large" />
           </Form.Item>
           <Form.Item
-            label="Recipient Zip Code"
+            label="Zip Code Where Service Received"
             name="zip_code"
             rules={[
               {

--- a/src/components/forms/AddServiceForm.js
+++ b/src/components/forms/AddServiceForm.js
@@ -178,7 +178,7 @@ function AddServiceForm({
             </Select>
           </Form.Item>
           <Form.Item
-            label="Address Where Service Received"
+            label="Service Address (not permanent address)"
             name="address"
             rules={[
               {
@@ -190,7 +190,7 @@ function AddServiceForm({
             <Input placeholder="Enter Street Address" size="large" />
           </Form.Item>
           <Form.Item
-            label="City Where Service Received"
+            label="Service City"
             name="city"
             rules={[
               {
@@ -202,7 +202,7 @@ function AddServiceForm({
             <Input placeholder="Enter City" size="large" />
           </Form.Item>
           <Form.Item
-            label="State Where Service Received"
+            label="Service State"
             name="state"
             rules={[
               {
@@ -214,7 +214,7 @@ function AddServiceForm({
             <Input placeholder="Enter State" size="large" />
           </Form.Item>
           <Form.Item
-            label="Zip Code Where Service Received"
+            label="Service Zip Code"
             name="zip_code"
             rules={[
               {


### PR DESCRIPTION

**What work was done?**

Renamed Log-A-Service form field names concerning location to communicate that these fields have to do with where a service was received, not where the recipient lives permanently 

**Why was this work done?**

To ensure the Service Providers using the log-a-service form understand exactly what the form is asking of them and can fill it out quicker and more accurately 

**What feature / user story is it for?**

Trello/User Story:
https://trello.com/c/vQFxOpI6

What This Looks Like In App:
https://lambda-students.slack.com/archives/C02AFKQBD2L/p1628699814208900


### Type of change

- improving existing feature (non-breaking change which adds functionality)

Change Status
- Completed, ready to review and merge

### Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- My code has been reviewed by at least one peer
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- There are no merge conflicts
