### PR TITLE
BUG FIX Added functional component for popups | added color changing …

### DIFF
--- a/src/components/pages/Dashboard/ServiceMap.js
+++ b/src/components/pages/Dashboard/ServiceMap.js
@@ -33,7 +33,6 @@ export default function ServiceMap(props) {
         key={`marker-${index}`}
         longitude={location.longitude}
         latitude={location.latitude}
-        n
       >
         {/* Changes the color of the marker through "property_name" and the dummy data from cities.json through the city-pin.js file | Will be updated once we get BE data*/}
         <CityPin


### PR DESCRIPTION
Dave noticed the last push didn't go through properly for ServiceMap.js with old code still being in place on main. This push is to try to fix the png code still being in place and replace it with the updated map.

Current Display on FE from these changes
![popupthroughSVG](https://user-images.githubusercontent.com/6081072/136730422-0e31b9df-e7ad-49cb-aef0-23af86203194.png)
![2 (2)](https://user-images.githubusercontent.com/6081072/136732324-b66eaeac-b2de-4e8c-8d86-3b9aef6d7113.png)


Description

What work was done?
- Added color changing functionality by created city-pin.js for map markers based on these colors per program:
        All Programs   #cad1d8
	Prevention  #7e3d74
	Shelter Support    #015c9b
	Aftercare    #dba94f
- Revised Andrew's dummy data for testing front end markers and clusters. in cities.json to get the color per program while trying to minimize merge conflicts from a last push we made at the same time on the same lines on serviceMap.js.
- Will switch to react-map-gl markers and clusters once data can be pulled from the BE
- Identified issue with menu displaying per user role and disabled menu user role fetch to populate main menu and header. 
- Added ! on line 57 in NavBarHeader.js ||  {!user.role ? (  
    -- Shows an error in fetching user role to show menu from BE. 



Why was this work done?

- To find the error with the navigation and main menu populating. I think its a user role fetch error.
- To setup color changing program markers and clusters


What feature / user story is it for?

- Adding to the map with centering of zoom
- Adding to the map with dummy data population of markers and clusters
- Adding to the map with stylization


Type of change

- Populating the navigation and main menu
- Centering of zoom on map
- Changing Andrew's Dummy Data to populate around Spokane
- Adding to the map with stylization via color per program


Testing

- Has this feature been tested before conflict? - yes locally
- Has this feature been tested after conflict? - yes locally


Change Status

- Completed, ready to review and merge


Checklist
My code follows the style guidelines of this project
I have performed a self-review of my own code
My code has been reviewed by at least one peer
I have commented my code, particularly in hard-to-understand areas
I have made corresponding changes to the documentation
My changes generate no new warnings
There are no merge conflicts

Next step is to reenable the React-Map-GL Markers and Clusters using geojson and props.data
Then we can disable the svg markers in place and reenable popups through the React-Map-GL markers and or clusters 

Loom Video
V.2 | Recode to avoid merge conflict by building on code from Andrew's Popup | https://www.loom.com/share/35e356a30f3b4602b61f439a7e4c194a
V.1 | Identifying Navbar display User Role issue | https://loom.com/share/dec6ad47b8484f5fa3919b06bcd70405


Removed a fix I had in place as NavBar was fixed by Salomon
- NavBar now loads - see below for error. - removed from previous pull.
Error with User Role and Nav Bar
![menu_burger_no_display](https://user-images.githubusercontent.com/6081072/136730445-08c17178-cdef-4f9a-88a3-602d2762a169.png)